### PR TITLE
meson: allow disabling LLVM static linking

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -81,7 +81,7 @@ if use_asmjit
 else
   sources = sources_common + sources_expr2
   incdir = include_directories('expr2/reactor')
-  deps += dependency('llvm', version: ['>= 10.0', '< 14'], method: 'config-tool', static: true,
+  deps += dependency('llvm', version: ['>= 10.0', '< 14'], method: 'config-tool', static: get_option('static-llvm'),
     modules: [
       'asmprinter', 'executionengine', 'target', 'orcjit', 'native',
     ])

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,2 @@
+option('static-llvm', type: 'boolean', value: true,
+       description: 'Whether to statically link LLVM')


### PR DESCRIPTION
As explained here: https://github.com/AkarinVS/vapoursynth-plugin/issues/7#issuecomment-1032637246

Some systems may already have LLVM installed, and statically linking may cause conflicts.