### PR TITLE
Make the plugin work with Av1an

### DIFF
--- a/expr2/reactor/LLVMJIT.cpp
+++ b/expr2/reactor/LLVMJIT.cpp
@@ -149,9 +149,6 @@ JITGlobals *JITGlobals::get()
 	static JITGlobals instance = [] {
 		const char *argv[] = {
 			"Reactor",
-#if defined(__i386__) || defined(__x86_64__)
-			"-x86-asm-syntax=intel",  // Use Intel syntax rather than the default AT&T
-#endif
 #if LLVM_VERSION_MAJOR <= 12
 			"-warn-stack-size=524288"  // Warn when a function uses more than 512 KiB of stack memory
 #else


### PR DESCRIPTION
[Av1an](https://github.com/master-of-zen/Av1an) is a video encoding framework to increase parallelization and threading to speed up encoding.

when inputting vs plugins with akarin as a dependency, it will error with this (probably rust thing?):
`Reactor: Unknown command line argument '-x86-asm-syntax=intel'.  Try: 'Reactor --help'
Reactor: Did you mean '--stats-json=intel'?`

This PR removed 3 lines of code in order to make it work again. 